### PR TITLE
[fix] Use the appropriate $GOPATH value for the operating system.

### DIFF
--- a/common/config.go
+++ b/common/config.go
@@ -1,8 +1,11 @@
 package common
 
 import   (
-	"github.com/spf13/viper"
 	"fmt"
+	"go/build"
+	"path/filepath"
+
+	"github.com/spf13/viper"
 )
 
 func init(){
@@ -13,7 +16,7 @@ func initConfig(){
 
 	viper.SetConfigType("yaml")
 	viper.SetConfigName("config")
-	viper.AddConfigPath("$GOPATH/src/github.com/it-chain/it-chain-Engine/conf")
+	viper.AddConfigPath(filepath.Join(build.Default.GOPATH, "/src/github.com/it-chain/it-chain-Engine/conf"))
 
 	//todo 데모용
 	//viper.AddConfigPath("./conf")


### PR DESCRIPTION
windows 에서 GOPATH 환경변수 인식을 못하는 듯 해서 수정요청 합니다.